### PR TITLE
remove stale symlink

### DIFF
--- a/src/karchive.cpp
+++ b/src/karchive.cpp
@@ -908,6 +908,11 @@ bool KArchiveDirectory::copyTo(const QString &dest, bool recursiveCopy) const
                     linkName += QLatin1String(".lnk");
                 }
 #endif
+                // remove the link name in case it exists, might have changed
+                // link target or be non-relative
+                if (QFile::exists(linkName) && linkName != curEntry->symLinkTarget()) {
+                    QFile::remove(linkName);
+                }
                 QFile symLinkTarget(curEntry->symLinkTarget());
                 if (!symLinkTarget.link(linkName)) {
                     //qCDebug(KArchiveLog) << "symlink(" << curEntry->symLinkTarget() << ',' << linkName << ") failed:" << strerror(errno);


### PR DESCRIPTION
when receiving a symlink, QFile::link will refuse in case the link already exist. This will cause updates to symlinks, or replacing files with a symlinked version to fail.