### PR TITLE
Make KArchive compile with MSVC

### DIFF
--- a/org_kde_karchive.pri
+++ b/org_kde_karchive.pri
@@ -37,4 +37,8 @@ HEADERS += \
 
 INCLUDEPATH += $$PWD/src/
 
-LIBS += -lz
+msvc {
+    LIBS += -luser32 -ladvapi32
+} else {
+    LIBS += -lz
+}


### PR DESCRIPTION
Our little .pri hack works, except on Windows we need to link some
system libs for GetUserNameW.
On the other hand we don't want to link zlib.