### PR TITLE
Fix clazy warning: use multi-arg qstring

### DIFF
--- a/src/karchive.cpp
+++ b/src/karchive.cpp
@@ -124,8 +124,7 @@ bool KArchive::createDevice(QIODevice::OpenMode mode)
             if (!d->saveFile->open(QIODevice::WriteOnly)) {
                 setErrorString(
                     tr("QSaveFile creation for %1 failed: %2")
-                        .arg(d->fileName)
-                        .arg(d->saveFile->errorString()));
+                        .arg(d->fileName, d->saveFile->errorString()));
 
                 delete d->saveFile;
                 d->saveFile = nullptr;
@@ -263,8 +262,7 @@ bool KArchive::addLocalFile(const QString &fileName, const QString &destName)
     if (!file.open(QIODevice::ReadOnly)) {
         setErrorString(
             tr("Couldn't open file %1: %2")
-            .arg(fileName)
-            .arg(file.errorString()));
+            .arg(fileName, file.errorString()));
         return false;
     }
 


### PR DESCRIPTION
I'm sure that this has been done upstream already and we'll eventually be able to drop this when re-basing
on a new karchive. Make clazy happy in the meantime.